### PR TITLE
Refactor movie form event handling

### DIFF
--- a/src/app/components/movie-card/movie-card.html
+++ b/src/app/components/movie-card/movie-card.html
@@ -15,15 +15,17 @@
         add_shopping_cart
       </mat-icon>
     </button>
-    <button mat-icon-button [routerLink]="['/movies/update/', movie.id]">
-      <mat-icon>
-        edit_square
-      </mat-icon>
-    </button>
-    <button mat-icon-button>
-      <mat-icon>
-        delete
-      </mat-icon>
-    </button>
+    @if (isLoggedIn) {
+      <button mat-icon-button [routerLink]="['/movies/update/', movie.id]">
+        <mat-icon>
+          edit_square
+        </mat-icon>
+      </button>
+      <button mat-icon-button (click)="confirmDelete()">
+        <mat-icon>
+          delete
+        </mat-icon>
+      </button>
+    }
   </mat-card-actions>
 </mat-card>

--- a/src/app/components/movie-card/movie-card.ts
+++ b/src/app/components/movie-card/movie-card.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { Movie } from '../../models/movie';
 import { CartService } from '../../services/cart.service';
@@ -6,15 +6,28 @@ import { MatIcon } from '@angular/material/icon';
 import { MatIconButton } from '@angular/material/button';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { AuthService } from '../../services/auth.service';
+import { MoviesService } from '../../services/movies.service';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'app-movie-card',
-  imports: [ MatIcon, MatIconButton, MatCardModule, RouterLink ],
+  imports: [ MatIcon, MatIconButton, MatCardModule, RouterLink, MatDialogModule ],
   templateUrl: './movie-card.html',
   styleUrl: './movie-card.scss'
 })
 export class MovieCard {
   @Input() movie: Movie;
+  @Output() deleteMovie: EventEmitter<string> = new EventEmitter<string>();
+
+  private dialog = inject(MatDialog);
+  private authService = inject(AuthService);
+  private moviesService = inject(MoviesService);
 
   constructor(private cartService: CartService, private snackBar: MatSnackBar) {
     this.movie = {
@@ -39,4 +52,55 @@ export class MovieCard {
       });
     }
   }
+
+  get isLoggedIn(): boolean {
+    return this.authService.isAuthenticated();
+  }
+
+  confirmDelete() {
+    const dialogRef = this.dialog.open(MovieDeleteConfirmationDialog, {
+      data: {
+        title: this.movie.title
+      }
+    });
+
+    dialogRef.afterClosed()
+      .pipe(filter((confirmed) => confirmed))
+      .subscribe(() => {
+        this.moviesService.delete(this.movie.id).subscribe({
+          next: () => {
+            this.snackBar.open('Filme excluído com sucesso!', 'Fechar', {
+              horizontalPosition: "end",
+              verticalPosition: "top",
+              duration: 3000
+            });
+            this.deleteMovie.emit(this.movie.id);
+          },
+          error: () => {
+            this.snackBar.open('Não foi possível excluir o filme.', 'Fechar', {
+              horizontalPosition: "end",
+              verticalPosition: "top",
+              duration: 3000
+            });
+          }
+        });
+      });
+  }
+}
+
+@Component({
+  selector: 'app-movie-delete-confirmation-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>Excluir filme</h2>
+    <mat-dialog-content>Tem certeza de que deseja excluir "{{ data.title }}"?</mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close="false">Cancelar</button>
+      <button mat-raised-button color="warn" [mat-dialog-close]="true">Excluir</button>
+    </mat-dialog-actions>
+  `
+})
+export class MovieDeleteConfirmationDialog {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { title: string }) {}
 }

--- a/src/app/components/movie-form/movie-form.html
+++ b/src/app/components/movie-form/movie-form.html
@@ -1,5 +1,11 @@
 <form [formGroup]="movieForm" (ngSubmit)="submitForm()">
-  <h3>Add new movie to Catalog</h3>
+  <h3>
+    @if (isEditMode()) {
+      Atualizar filme
+    } @else {
+      Adicionar novo filme ao catálogo
+    }
+  </h3>
 
   <mat-form-field appearance="fill">
     <mat-label>Title</mat-label>
@@ -43,7 +49,16 @@
     <label class="block mb-1">Poster image</label>
 
     <input type="file" #fileInput accept="image/*" style="display: none;" (change)="onFileSelected($event)" />
-    <button mat-raised-button color="primary" (click)="fileInput.click()" type="button">Choose File</button>
+    <button mat-raised-button color="primary" (click)="fileInput.click()" type="button">
+      @if (isEditMode()) {
+        Alterar poster
+      } @else {
+        Escolher arquivo
+      }
+    </button>
+    @if (isEditMode()) {
+      <small class="hint">Caso não selecione uma nova imagem, o poster atual será mantido.</small>
+    }
     @if (fileError) {
       <mat-error>{{ fileError }}</mat-error>
     }
@@ -87,5 +102,11 @@
     }
   </mat-form-field>
 
-  <button mat-raised-button color="primary" type="submit">Submit</button>
+  <button mat-raised-button color="primary" type="submit">
+    @if (isEditMode()) {
+      Salvar alterações
+    } @else {
+      Cadastrar filme
+    }
+  </button>
 </form>

--- a/src/app/components/movie-form/movie-form.scss
+++ b/src/app/components/movie-form/movie-form.scss
@@ -5,3 +5,9 @@ form {
     max-width: 500px;
     margin: auto;
 }
+
+.hint {
+    display: block;
+    margin-top: 8px;
+    color: rgba(0, 0, 0, 0.6);
+}

--- a/src/app/pages/movies-list/movies-list.html
+++ b/src/app/pages/movies-list/movies-list.html
@@ -1,6 +1,6 @@
 <div class="container">
     @for (movie of movies; track movie.id) {
-        <app-movie-card [movie]="movie"/>
+        <app-movie-card [movie]="movie" (deleteMovie)="onMovieDeleted($event)"/>
     }
     @empty {
         <b>Nenhum filme cadastrado</b>

--- a/src/app/pages/movies-list/movies-list.ts
+++ b/src/app/pages/movies-list/movies-list.ts
@@ -18,7 +18,10 @@ export class MoviesList implements OnInit {
   ngOnInit(): void {
     this.moviesService.getAll().subscribe((movies) => {
       this.movies = movies;
-      console.log(this.movies);
     });
+  }
+
+  onMovieDeleted(id: string) {
+    this.movies = this.movies.filter((movie) => movie.id !== id);
   }
 }

--- a/src/app/pages/movies-registration/movies-registration.html
+++ b/src/app/pages/movies-registration/movies-registration.html
@@ -1,1 +1,1 @@
-<app-movie-form />
+<app-movie-form (createMovie)="handleCreateMovie($event)" />

--- a/src/app/pages/movies-registration/movies-registration.ts
+++ b/src/app/pages/movies-registration/movies-registration.ts
@@ -1,5 +1,10 @@
-import { Component } from '@angular/core';
-import { MovieForm } from '../../components/movie-form/movie-form';
+import { Component, ViewChild, inject } from '@angular/core';
+import { switchMap } from 'rxjs';
+
+import { MovieForm, MovieFormCreateEvent } from '../../components/movie-form/movie-form';
+import { MoviesService } from '../../services/movies.service';
+import { Movie } from '../../models/movie';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-movies-registration',
@@ -8,5 +13,44 @@ import { MovieForm } from '../../components/movie-form/movie-form';
   styleUrl: './movies-registration.scss'
 })
 export class MoviesRegistration {
+  @ViewChild(MovieForm) movieForm?: MovieForm;
+
+  private readonly moviesService = inject(MoviesService);
+  private readonly snackBar = inject(MatSnackBar);
+
+  handleCreateMovie(event: MovieFormCreateEvent) {
+    const { formValue, file } = event;
+
+    this.moviesService
+      .uploadImage(file)
+      .pipe(
+        switchMap(({ imageUrl }) => {
+          const payload: Omit<Movie, 'id'> = {
+            ...formValue,
+            imageLink: imageUrl
+          };
+
+          return this.moviesService.create(payload);
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.movieForm?.resetAfterCreate();
+          this.snackBar.open('Filme adicionado com sucesso!', 'Fechar', {
+            horizontalPosition: 'end',
+            verticalPosition: 'top',
+            duration: 3000
+          });
+        },
+        error: (error) => {
+          console.error(error);
+          this.snackBar.open('Não foi possível adicionar o filme.', 'Fechar', {
+            horizontalPosition: 'end',
+            verticalPosition: 'top',
+            duration: 3000
+          });
+        }
+      });
+  }
 
 }

--- a/src/app/pages/movies-update/movies-update.html
+++ b/src/app/pages/movies-update/movies-update.html
@@ -1,1 +1,1 @@
-<app-movie-form [movie]="movie"/>
+<app-movie-form [movie]="movie" (updateMovie)="handleUpdateMovie($event)" />

--- a/src/app/pages/movies-update/movies-update.ts
+++ b/src/app/pages/movies-update/movies-update.ts
@@ -1,7 +1,9 @@
 import { Component, signal, WritableSignal } from '@angular/core';
-import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Observable, switchMap } from 'rxjs';
 
-import { MovieForm } from '../../components/movie-form/movie-form';
+import { MovieForm, MovieFormUpdateEvent } from '../../components/movie-form/movie-form';
 import { MoviesService } from '../../services/movies.service';
 import { Movie } from '../../models/movie';
 
@@ -14,10 +16,61 @@ import { Movie } from '../../models/movie';
 export class MoviesUpdate {
   movie: WritableSignal<Movie | null> = signal(null);
 
-  constructor(private moviesService: MoviesService, private activatedRoute: ActivatedRoute) {
+  constructor(
+    private moviesService: MoviesService,
+    private activatedRoute: ActivatedRoute,
+    private snackBar: MatSnackBar
+  ) {
     const id = this.activatedRoute.snapshot.params['id'];
     this.moviesService.getById(id).subscribe((foundMovie) => {
       this.movie.set(foundMovie);
+    });
+  }
+
+  handleUpdateMovie(event: MovieFormUpdateEvent) {
+    const { formValue, movie, newFile } = event;
+
+    let update$: Observable<Movie>;
+
+    if (newFile) {
+      update$ = this.moviesService.uploadImage(newFile).pipe(
+        switchMap(({ imageUrl }) => {
+          const payload: Movie = {
+            ...formValue,
+            id: movie.id,
+            imageLink: imageUrl
+          };
+
+          return this.moviesService.update(movie.id, payload);
+        })
+      );
+    } else {
+      const payload: Movie = {
+        ...formValue,
+        id: movie.id,
+        imageLink: movie.imageLink
+      };
+
+      update$ = this.moviesService.update(movie.id, payload);
+    }
+
+    update$.subscribe({
+      next: (updatedMovie) => {
+        this.movie.set(updatedMovie);
+        this.snackBar.open('Filme atualizado com sucesso!', 'Fechar', {
+          horizontalPosition: 'end',
+          verticalPosition: 'top',
+          duration: 3000
+        });
+      },
+      error: (error) => {
+        console.error(error);
+        this.snackBar.open('Não foi possível atualizar o filme.', 'Fechar', {
+          horizontalPosition: 'end',
+          verticalPosition: 'top',
+          duration: 3000
+        });
+      }
     });
   }
 }

--- a/src/app/services/movies.service.ts
+++ b/src/app/services/movies.service.ts
@@ -22,8 +22,16 @@ export class MoviesService {
     return this.http.get<Movie>(`${this.API_URL}movies/${id}`);
   }
 
-  create(movie: Movie) {
+  create(movie: Omit<Movie, 'id'>) {
     return this.http.post<Movie>(`${this.API_URL}movies`, movie)
+  }
+
+  update(id: string, movie: Movie) {
+    return this.http.put<Movie>(`${this.API_URL}movies/${id}`, movie);
+  }
+
+  delete(id: string) {
+    return this.http.delete<void>(`${this.API_URL}movies/${id}`);
   }
 
   uploadImage(file: File): Observable<{ imageUrl: string; path?: string }> {


### PR DESCRIPTION
## Summary
- emit dedicated create and update events from the shared movie form instead of coupling it to the movie service
- handle the emitted payloads inside the registration and update pages, including poster uploads, API calls, and user feedback
- expose a helper on the form to reset itself after a successful creation when triggered by the parent

## Testing
- npm run build *(fails: `ng` CLI not available because `@angular/cli` cannot be downloaded in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f9908dd4832fbc2e472058d6f432