### PR TITLE
feat: add stripe checkout modal to cart

### DIFF
--- a/src/app/components/cart/cart.html
+++ b/src/app/components/cart/cart.html
@@ -1,21 +1,30 @@
 <mat-list>
-    @for(item of cartArray; track item.movie.id) {
-        <mat-list-item>
-            <div class="list-item">
-                <div>{{ item.movie.title }}</div>
-                <div>
-                    <button mat-icon-button (click)="removeItem(item)">
-                        <mat-icon>remove</mat-icon>
-                    </button>
-                    <span>{{ item.quantity }}</span>
-                    <button mat-icon-button (click)="addItem(item)" [disabled]="item.quantity >= item.movie.availableInStock">
-                        <mat-icon>add</mat-icon>
-                    </button>
-                </div>
-            </div>
-        </mat-list-item>
-        <mat-divider></mat-divider>
-    }
-
-    <b>Total da Compra: {{ getTotalPrice() | currency:'R$' }}</b>
+  @for(item of cartArray; track item.movie.id) {
+    <mat-list-item>
+      <div class="list-item">
+        <div>{{ item.movie.title }}</div>
+        <div>
+          <button mat-icon-button (click)="removeItem(item)">
+            <mat-icon>remove</mat-icon>
+          </button>
+          <span>{{ item.quantity }}</span>
+          <button
+            mat-icon-button
+            (click)="addItem(item)"
+            [disabled]="item.quantity >= item.movie.availableInStock"
+          >
+            <mat-icon>add</mat-icon>
+          </button>
+        </div>
+      </div>
+    </mat-list-item>
+    <mat-divider></mat-divider>
+  }
 </mat-list>
+
+<div class="cart-footer">
+  <b>Total da Compra: {{ getTotalPrice() | currency: 'R$' }}</b>
+  <button mat-flat-button color="primary" (click)="openPaymentModal()">
+    Finalizar pagamento
+  </button>
+</div>

--- a/src/app/components/cart/cart.scss
+++ b/src/app/components/cart/cart.scss
@@ -2,4 +2,18 @@
     font-size: 25px;
     display: flex;
     justify-content: space-between;
+    align-items: center;
+}
+
+.cart-footer {
+    margin-top: 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    font-size: 1.1rem;
+}
+
+.cart-footer button {
+    white-space: nowrap;
 }

--- a/src/app/components/cart/cart.ts
+++ b/src/app/components/cart/cart.ts
@@ -3,13 +3,17 @@ import { CartItem } from '../../models/cart-item';
 import { CartService } from '../../services/cart.service';
 import { MatIcon } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
-import { MatIconButton } from '@angular/material/button';
+import { MatButtonModule, MatIconButton } from '@angular/material/button';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CurrencyPipe } from '@angular/common';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
+
+import { PaymentModal } from '../payment-modal/payment-modal';
 
 @Component({
   selector: 'app-cart',
-  imports: [ MatIcon, MatIconButton,  MatListModule, CurrencyPipe ],
+  imports: [ MatIcon, MatIconButton, MatButtonModule, MatDialogModule, MatListModule, MatDividerModule, CurrencyPipe ],
   templateUrl: './cart.html',
   styleUrl: './cart.scss'
 })
@@ -17,7 +21,11 @@ export class Cart implements OnInit {
   cartArray: Array<CartItem> = [];
   getTotalPrice: Signal<number> = signal<number>(0);
 
-  constructor(private cartService: CartService, private snackBar: MatSnackBar) {
+  constructor(
+    private cartService: CartService,
+    private snackBar: MatSnackBar,
+    private dialog: MatDialog
+  ) {
     this.getTotalPrice = this.cartService.getTotalPrice;
   }
 
@@ -40,5 +48,24 @@ export class Cart implements OnInit {
 
   removeItem(item: CartItem) {
     this.cartService.removeItem(item.movie);
+  }
+
+  openPaymentModal() {
+    if (!this.cartArray.length) {
+      this.snackBar.open('Adicione itens ao carrinho antes de finalizar a compra.', 'Fechar', {
+        horizontalPosition: 'end',
+        verticalPosition: 'top',
+        duration: 3000
+      });
+      return;
+    }
+
+    this.dialog.open(PaymentModal, {
+      data: {
+        total: this.getTotalPrice(),
+        items: this.cartArray
+      },
+      width: '500px'
+    });
   }
 }

--- a/src/app/components/payment-modal/payment-modal.html
+++ b/src/app/components/payment-modal/payment-modal.html
@@ -1,0 +1,35 @@
+<h2 mat-dialog-title>Finalizar pagamento</h2>
+<mat-dialog-content>
+  <p>Revise os itens e informe os dados do cartão para concluir a compra.</p>
+  <div class="summary">
+    <span>Total a pagar</span>
+    <strong>{{ data.total | currency: 'R$' }}</strong>
+  </div>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Nome impresso no cartão</mat-label>
+    <input matInput [(ngModel)]="cardHolderName" placeholder="Ex.: Maria Souza" />
+  </mat-form-field>
+
+  <label class="field-label">Dados do cartão</label>
+  <div #cardElement class="card-element"></div>
+
+  <div *ngIf="statusMessage" class="status">{{ statusMessage }}</div>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="close()" [disabled]="loading">Cancelar</button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    (click)="submitPayment()"
+    [disabled]="loading || !stripeReady"
+  >
+    <mat-progress-spinner
+      *ngIf="loading"
+      diameter="18"
+      mode="indeterminate"
+    ></mat-progress-spinner>
+    <span *ngIf="!loading">Pagar agora</span>
+  </button>
+</mat-dialog-actions>

--- a/src/app/components/payment-modal/payment-modal.scss
+++ b/src/app/components/payment-modal/payment-modal.scss
@@ -1,0 +1,34 @@
+.summary {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.card-element {
+  padding: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  min-height: 48px;
+}
+
+.status {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #1565c0;
+}
+
+mat-progress-spinner {
+  margin-right: 0.5rem;
+}

--- a/src/app/components/payment-modal/payment-modal.ts
+++ b/src/app/components/payment-modal/payment-modal.ts
@@ -1,0 +1,118 @@
+import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
+import { CommonModule, CurrencyPipe, NgIf } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { CartItem } from '../../models/cart-item';
+import {
+  StripeCardElement,
+  StripeElements,
+  StripeInstance,
+  StripeLoaderService
+} from '../../services/stripe-loader.service';
+
+interface PaymentModalData {
+  total: number;
+  items: CartItem[];
+}
+
+@Component({
+  selector: 'app-payment-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    NgIf,
+    FormsModule,
+    CurrencyPipe,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './payment-modal.html',
+  styleUrl: './payment-modal.scss'
+})
+export class PaymentModal implements AfterViewInit, OnDestroy {
+  @ViewChild('cardElement', { static: true })
+  cardElement?: ElementRef<HTMLDivElement>;
+
+  cardHolderName = '';
+  loading = false;
+  stripeReady = false;
+  statusMessage = '';
+
+  private stripe: StripeInstance | null = null;
+  private elements: StripeElements | null = null;
+  private card?: StripeCardElement;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: PaymentModalData,
+    private dialogRef: MatDialogRef<PaymentModal>,
+    private stripeLoader: StripeLoaderService
+  ) {}
+
+  async ngAfterViewInit(): Promise<void> {
+    await this.initializeStripe();
+  }
+
+  ngOnDestroy(): void {
+    this.card?.destroy();
+  }
+
+  async submitPayment(): Promise<void> {
+    if (!this.stripe || !this.card) {
+      this.statusMessage = 'O Stripe ainda está inicializando. Tente novamente em instantes.';
+      return;
+    }
+
+    this.loading = true;
+    this.statusMessage = '';
+
+    try {
+      const { error, paymentMethod } = await this.stripe.createPaymentMethod({
+        type: 'card',
+        card: this.card,
+        billing_details: {
+          name: this.cardHolderName || undefined
+        }
+      });
+
+      if (error) {
+        this.statusMessage = error.message ?? 'Não foi possível criar o método de pagamento.';
+      } else if (paymentMethod) {
+        this.statusMessage = `Pagamento autorizado! Código: ${paymentMethod.id}.`;
+      }
+    } catch (error) {
+      this.statusMessage = 'Ocorreu um erro inesperado. Tente novamente em instantes.';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+
+  private async initializeStripe(): Promise<void> {
+    this.stripe = await this.stripeLoader.loadStripe();
+
+    if (!this.stripe) {
+      this.statusMessage = 'Não foi possível inicializar o Stripe. Verifique sua configuração.';
+      return;
+    }
+
+    if (!this.cardElement) {
+      this.statusMessage = 'Elemento de cartão não encontrado.';
+      return;
+    }
+
+    this.elements = this.stripe.elements({ locale: 'pt-BR' });
+    this.card = this.elements.create('card');
+    this.card.mount(this.cardElement.nativeElement);
+    this.stripeReady = true;
+  }
+}

--- a/src/app/services/stripe-loader.service.ts
+++ b/src/app/services/stripe-loader.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+
+import { STRIPE_PUBLISHABLE_KEY } from '../utils/stripe.config';
+
+export interface StripePaymentMethodResult {
+  error?: { message?: string };
+  paymentMethod?: { id: string };
+}
+
+export interface StripeCardElement {
+  mount(element: HTMLElement): void;
+  destroy(): void;
+}
+
+export interface StripeElements {
+  create(type: 'card'): StripeCardElement;
+}
+
+export interface StripeInstance {
+  elements(options?: { locale?: string }): StripeElements;
+  createPaymentMethod(options: {
+    type: 'card';
+    card: StripeCardElement;
+    billing_details?: { name?: string };
+  }): Promise<StripePaymentMethodResult>;
+}
+
+interface StripeConstructor {
+  (key: string): StripeInstance;
+}
+
+interface StripeWindow extends Window {
+  Stripe?: StripeConstructor;
+}
+
+@Injectable({ providedIn: 'root' })
+export class StripeLoaderService {
+  private stripePromise?: Promise<StripeInstance | null>;
+  private stripeInstance: StripeInstance | null = null;
+
+  loadStripe(): Promise<StripeInstance | null> {
+    if (!STRIPE_PUBLISHABLE_KEY) {
+      return Promise.resolve(null);
+    }
+
+    if (this.stripeInstance) {
+      return Promise.resolve(this.stripeInstance);
+    }
+
+    if (!this.stripePromise) {
+      this.stripePromise = new Promise((resolve) => {
+        if (typeof window === 'undefined') {
+          resolve(null);
+          return;
+        }
+
+        const stripeWindow = window as StripeWindow;
+
+        if (stripeWindow.Stripe) {
+          this.stripeInstance = stripeWindow.Stripe(STRIPE_PUBLISHABLE_KEY);
+          resolve(this.stripeInstance);
+          return;
+        }
+
+        const script = document.createElement('script');
+        script.src = 'https://js.stripe.com/v3/';
+        script.async = true;
+        script.onload = () => {
+          if (stripeWindow.Stripe) {
+            this.stripeInstance = stripeWindow.Stripe(STRIPE_PUBLISHABLE_KEY);
+            resolve(this.stripeInstance);
+          } else {
+            resolve(null);
+          }
+        };
+        script.onerror = () => resolve(null);
+        document.body.appendChild(script);
+      });
+    }
+
+    return this.stripePromise;
+  }
+}

--- a/src/app/utils/stripe.config.ts
+++ b/src/app/utils/stripe.config.ts
@@ -1,0 +1,5 @@
+/**
+ * Publishable key used by Stripe.js. Replace this value with the key provided by Stripe for the
+ * desired environment (test or production) before deploying.
+ */
+export const STRIPE_PUBLISHABLE_KEY = 'pk_test_51H0xxxxExampleKeyChangeMe';


### PR DESCRIPTION
## Summary
- add a checkout button in the cart that opens a Stripe-powered payment modal via MatDialog
- create a standalone payment modal component and Stripe loader service to render card entry and feedback

## Testing
- npm run build *(fails: 403 when Angular CLI tries to inline Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68d683d63a6c832f8e04cdcbd864fff9